### PR TITLE
Update getting-started.mdx

### DIFF
--- a/packages/website/src/content/docs/guides/getting-started.mdx
+++ b/packages/website/src/content/docs/guides/getting-started.mdx
@@ -33,7 +33,7 @@ You can get started by using one of the demo projects or following the quick sta
    // +page.svelte
    <script>
      import {RichTextComposer} from 'svelte-lexical';
-     import {theme as editorTheme} from 'svelte-lexical/dist/themes/default';
+     import {theme} from 'svelte-lexical/dist/themes/default';
    </script>
    ```
 


### PR DESCRIPTION
I followed the getting started doc but usage of `{theme as editorTheme}` broke the later `<RichTextComposer {theme}` for me. Removing the `as editorTheme` renaming fixed it. Note also that in step 4 there is no `as editorTheme` so this PR removes it for step 3