### PR TITLE
Fix Svelte 5 runes mode compatibility

### DIFF
--- a/packages/svelte-lexical/src/lib/core/plugins/ColumnsLayout/ColumnLayoutPlugin.svelte
+++ b/packages/svelte-lexical/src/lib/core/plugins/ColumnsLayout/ColumnLayoutPlugin.svelte
@@ -44,7 +44,7 @@
       );
     }
 
-    const $onEscape = (before: boolean) => {
+    const onEscape = (before: boolean) => {
       const selection = getSelection();
       if (
         isRangeSelection(selection) &&
@@ -110,12 +110,12 @@
       // new content even if trailing paragraph is accidentally deleted
       editor.registerCommand(
         KEY_ARROW_DOWN_COMMAND,
-        () => $onEscape(false),
+        () => onEscape(false),
         COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         KEY_ARROW_RIGHT_COMMAND,
-        () => $onEscape(false),
+        () => onEscape(false),
         COMMAND_PRIORITY_LOW,
       ),
       // When layout is the first child pressing up/left arrow will insert paragraph
@@ -124,12 +124,12 @@
       // new content even if leading paragraph is accidentally deleted
       editor.registerCommand(
         KEY_ARROW_UP_COMMAND,
-        () => $onEscape(true),
+        () => onEscape(true),
         COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
         KEY_ARROW_LEFT_COMMAND,
-        () => $onEscape(true),
+        () => onEscape(true),
         COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(


### PR DESCRIPTION
## Summary
- Rename `$onEscape` to `onEscape` in ColumnLayoutPlugin.svelte

## Problem
The `$` prefix is reserved in Svelte 5 when `compilerOptions.runes = true` is set. This causes build errors:

```
The $ prefix is reserved, and cannot be used for variables and imports
```

## Solution
Rename the internal `$onEscape` variable to `onEscape`. This was the only `$`-prefixed local variable in `.svelte` files (the `$` functions in `.ts` files are Lexical API convention and work fine).

Fixes #117

## Test plan
- [x] `pnpm check` passes
- [ ] CI tests