### PR TITLE
build: add margin to demo size-limits

### DIFF
--- a/demos/plaintext-editor/package.json
+++ b/demos/plaintext-editor/package.json
@@ -31,7 +31,7 @@
   },
   "size-limit": [
     {
-      "limit": "80 kb",
+      "limit": "85 kb",
       "path": "dist/assets/index-*.js"
     }
   ]

--- a/demos/playground/package.json
+++ b/demos/playground/package.json
@@ -97,7 +97,7 @@
   },
   "size-limit": [
     {
-      "limit": "225 kb",
+      "limit": "230 kb",
       "path": "dist/assets/main-*.js"
     }
   ]

--- a/demos/richtext-editor/package.json
+++ b/demos/richtext-editor/package.json
@@ -31,7 +31,7 @@
   },
   "size-limit": [
     {
-      "limit": "115 kb",
+      "limit": "125 kb",
       "path": "dist/assets/index-*.js"
     }
   ]


### PR DESCRIPTION
This adds a small buffer to demo size-limits to reduce frequent tiny bumps after dependency upgrades.

- playground: 220kb -> 230kb
- plaintext-editor: 80kb -> 85kb
- richtext-editor: 115kb -> 125kb